### PR TITLE
use the `typeof` to check `function`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ function tabledriven () {
   }
 
   const array = Array.isArray(a[0]) ? a[0] : false
-  const fn = (toString.call(a[1]) === '[object Function]') ? a[1] : false
+  const fn = (typeof a[1] === 'function') ? a[1] : false
   const isAsync = (typeof a[2] === 'undefined') ? false : a[2]
 
   if (array === false) {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof
with ECMA-262
Function object (implements [[Call]] in ECMA-262 terms)	 can be checked by `typeof`